### PR TITLE
Replace memcpy with memmove

### DIFF
--- a/module/pna_flowmon.c
+++ b/module/pna_flowmon.c
@@ -207,7 +207,7 @@ int flowmon_hook(struct pna_flowkey *key, int direction, unsigned short flags,
 		/* check for free spot -- insert flow entry */
 		if (flowkey_match(&flow->key, &null_key)) {
 			/* copy over the flow key for this entry */
-			memcpy(&flow->key, key, sizeof(*key));
+			memmove(&flow->key, key, sizeof(*key));
 
 			/* port specific information */
 			flow->data.bytes[direction] += pkt_len + ETH_OVERHEAD;


### PR DESCRIPTION
This PR replaces the call to `memcpy` in `pna_flowmon.c` with a call to `memmove`. This allows for platforms with older versions of glibc (e.g. RHEL 5) to work with non-static binaries that are built with newer versions of glibc (e.g. Ubuntu Trusty).

Before:

```
$ objdump -T module/pna | tail -n+5 | cut -f2 | cut -d' ' -f3 | sort -u

GLIBC_2.14
GLIBC_2.2.5
GLIBC_2.4

```

After:

```
$ objdump -T module/pna | tail -n+5 | cut -f2 | cut -d' ' -f3 | sort -u

GLIBC_2.2.5
GLIBC_2.4
```

[memcpy](http://linux.die.net/man/3/memcpy) and [memmove](http://linux.die.net/man/3/memmove) are similar (So similar that [sometimes they're exactly the same](http://www.win.tue.nl/~aeb/linux/misc/gcc-semibug.html)). There's theoretically a performance penalty for using `memmove`, but [Linus himself](https://sourceware.org/bugzilla/show_bug.cgi?id=12518#c10) says it's not actually slower.
