### PR TITLE
Return value in rtmon_hook

### DIFF
--- a/module/pna_rtmon.c
+++ b/module/pna_rtmon.c
@@ -56,13 +56,14 @@ int rtmon_hook(struct pna_flowkey *key, int direction, const unsigned char *pkt,
                unsigned int pkt_len, const struct timeval tv,
                unsigned long data)
 {
-	int ret;
+	int ret = 0;
 
 	struct pna_rtmon *monitor;
 
 	for (monitor = &monitors[0]; monitor->hook != NULL; monitor++)
 		ret = monitor->hook(key, direction, pkt, pkt_len, tv, &data);
-	return 0;
+
+	return ret;
 }
 
 /* initialize all the resources needed for each rtmon */


### PR DESCRIPTION
It appears nothing actually uses the return value from this function, but returning `0` after setting `ret` seems like an oversight.

(This was the only thing clang's `scan-build` noted besides memory leaks of the command line argument strings.)
